### PR TITLE
Fix DiscreteCurvaturesAndNormalsTest

### DIFF
--- a/projects/discrete-curvatures-and-normals/src/test-curv.cpp
+++ b/projects/discrete-curvatures-and-normals/src/test-curv.cpp
@@ -294,7 +294,7 @@ TEST_F(DiscreteCurvaturesAndNormalsTest, principalCurvatures) {
             allKMinCorrect = false;
         }
         if (abs(k2 - k2_soln) > 1e-5) {
-            allKMinCorrect = false;
+            allKMaxCorrect = false;
         }
         if (!allKMinCorrect && !allKMaxCorrect) {
             break;


### PR DESCRIPTION
Fixed a small issue in DiscreteCurvaturesAndNormalsTest from Assignment 2 (Coding) in the discrete-curvatures-and-normals project.

In line 297 allKMaxCorrect should be set instead of allKMinCorrect.